### PR TITLE
Setup tests and code coverage

### DIFF
--- a/api/.coveragerc
+++ b/api/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+  *apps.py,
+  *migrations/*,
+  *settings*,
+  *tests/*,
+  *urls.py,
+  *wsgi/*,
+  manage.py

--- a/api/docker-compose.test.yml
+++ b/api/docker-compose.test.yml
@@ -1,0 +1,14 @@
+version: '3.7'
+
+services:
+  db:
+    image: postgres:12.0-alpine
+    environment:
+      - POSTGRES_DB=prontolista
+      - POSTGRES_USER=prontolista
+
+  app:
+    image: prontolista
+    build:
+      context: .
+      dockerfile: compose/django/Dockerfile-local

--- a/api/prontolista/prontolista/settings/test.py
+++ b/api/prontolista/prontolista/settings/test.py
@@ -1,0 +1,13 @@
+from .base import *
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': os.environ.get('DATABASE_NAME', 'prontolista'),
+        'USER': os.environ.get('DATABASE_USER', 'prontolista'),
+        'PASSWORD': os.environ.get('DATABASE_PASSWORD', ''),
+        'HOST': os.environ.get('DATABASE_HOST', 'db'),
+        'PORT': os.environ.get('DATABASE_PORT', '5432'),
+    }
+}

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+DJANGO_SETTINGS_MODULE = prontolista.settings.test

--- a/api/pytest.ini
+++ b/api/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = prontolista.settings.test
+addopts = --nomigrations --cov=prontolista --cov-report=html --cov-report=term-missing


### PR DESCRIPTION
Changes proposed in this pull request:
* Add pytest configuration
* Test has its own Django test settings
* Configure code coverage report (stdout and html)
* Add Docker compose file for test (will be used in CI)