### PR TITLE
Fix Docker build steps for local development :bear:

### DIFF
--- a/api/compose/django/Dockerfile-local
+++ b/api/compose/django/Dockerfile-local
@@ -4,10 +4,9 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=on
 
 RUN pip install poetry==0.12.17
 
-COPY poetry.lock pyproject.toml /
-RUN poetry config settings.virtualenvs.create false
-RUN poetry install --no-interaction
 COPY . /app/
 COPY compose/django/docker-entrypoint-local.sh /docker-entrypoint.sh
 WORKDIR /app
+RUN poetry config settings.virtualenvs.create false
+RUN poetry install --no-interaction
 RUN chmod +x /docker-entrypoint.sh


### PR DESCRIPTION
Changes proposed in this pull request:
* Since we ignore `poetry.lock` during the Docker build for dev and production, we need to change how we build the Docker image for local development as well.