### PR TITLE
Add string representation for TestRun model

### DIFF
--- a/api/prontolista/testruns/models.py
+++ b/api/prontolista/testruns/models.py
@@ -8,3 +8,6 @@ from projects.models import Project
 class TestRun(TimeStampedModel):
     name = models.CharField(max_length=300)
     project = models.ForeignKey(Project, on_delete=models.CASCADE)
+
+    def __str__(self):
+        return self.name

--- a/api/prontolista/testruns/tests/test_models.py
+++ b/api/prontolista/testruns/tests/test_models.py
@@ -16,3 +16,10 @@ class TestRunTest(TestCase):
         assert actual.project.name == project.name
         assert actual.created
         assert actual.modified
+
+    def test_model_should_get_name_as_string_representation(self):
+        project = baker.make(Project)
+        expected_name = "Upgrade wordpress dependencies"
+        actual = TestRun.objects.create(name=expected_name, project=project)
+
+        assert actual.__str__() == expected_name


### PR DESCRIPTION
Change proposed in this pull request
- Add string representation for TestRun model. So we can easier to test.
