### PR TITLE
Change configuration for mypy to use django-stubs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,8 @@ jobs:
       - run:
           name: Run Type Checker
           command: |
-            poetry run mypy prontolista
+            cd prontolista/
+            poetry run mypy --config-file=../mypy.ini .
       - run:
           name: Run Tests
           command: |

--- a/api/mypy.ini
+++ b/api/mypy.ini
@@ -18,20 +18,11 @@ warn_unused_configs = True
 warn_unreachable = True
 warn_no_return = True
 
-[mypy-prontolista.settings.*]
-ignore_errors = True
+plugins =
+  mypy_django_plugin.main
 
-[mypy-projects.models]
-ignore_errors = True
+[mypy.plugins.django-stubs]
+django_settings_module = prontolista.settings.base
 
-[mypy-projects.migrations.*]
-ignore_errors = True
-
-[mypy-testcases.models]
-ignore_errors = True
-
-[mypy-testruns.models]
-ignore_errors = True
-
-[mypy-test_instances.models]
+[mypy-*.migrations.*]
 ignore_errors = True

--- a/api/prontolista/prontolista/settings/production.py
+++ b/api/prontolista/prontolista/settings/production.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *
 
 


### PR DESCRIPTION
We need to use mypy_django_plugin so that mypy would know where should
it looking for stub file. This plugin required only 1 thing which is we
need to tell where is the django_settings_module is for the project

Another configuration I add is [mypy-*.migrations.*] which we gonna
ignore all error produce from the migrations file. Declaring it like
this will apply to the app we will add in the future as well without
re-configuration mypy again

The only downside for using mypy-django-plugins is that we need to run
it at the root of django project, So that mypy would be able to collect
the module for each app (related to this issue typeddjango/django-stubs#133)

Lastly, we need to add import os in production settings since mypy
wouldn't know the import * format