### PR TITLE
Fix width of test instance when add a new one on test run admin

### DIFF
--- a/api/prontolista/templates/admin/base_site.html
+++ b/api/prontolista/templates/admin/base_site.html
@@ -12,7 +12,7 @@
     // Credit: https://yuji.wordpress.com/2014/05/05/select2-autocomplete-in-the-django-suit-admin/
     $(() => {
       select2Options = {
-        'width': 'resolve',
+        'width': '220px',
       }
       $('#content-main select:not(.select2-offscreen)').select2(select2Options)
       Suit.after_inline.register('fire_up_select2', (inline_prefix, row) => {


### PR DESCRIPTION
Changes proposed in this pull request:
* The `resolve` property causes the issue. I've fixed the width to 220 px instead.